### PR TITLE
Use Maven Wrapper in CI Workflows and Update Dependencies

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,11 @@ jobs:
           java-version: 17
           distribution: 'zulu'
 
+      # Ensure Maven wrapper is executable
+      - name: Make Maven Wrapper executable
+        run: chmod +x ./mvnw
+
       # Build and run tests
       - name: Maven package
         run: |
-          mvn -ntp -B package
+          ./mvnw -ntp -B package

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,11 +25,15 @@ jobs:
           java-version: 17
           distribution: 'zulu'
 
+      # Ensure Maven wrapper is executable
+      - name: Make Maven Wrapper executable
+        run: chmod +x ./mvnw
+
       # Prepare for upload to Maven Central
       # https://jreleaser.org/guide/latest/examples/maven/staging-artifacts.html
       - name: Build for release
         run: |
-          mvn -ntp -B -Ppublication deploy -DaltDeploymentRepository=local::file:./target/staging-deploy
+          ./mvnw -ntp -B -Ppublication deploy -DaltDeploymentRepository=local::file:./target/staging-deploy
 
       - name: List files staged for release
         run: |
@@ -45,7 +49,7 @@ jobs:
           JRELEASER_GPG_PUBLIC_KEY: ${{ secrets.JRELEASER_GPG_PUBLIC_KEY }}
           JRELEASER_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          mvn -ntp -B jreleaser:config
+          ./mvnw -ntp -B jreleaser:config
 
       # Only release when approved
       - name: Get release approval
@@ -65,4 +69,4 @@ jobs:
           JRELEASER_GPG_PUBLIC_KEY: ${{ secrets.JRELEASER_GPG_PUBLIC_KEY }}
           JRELEASER_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          mvn -ntp -B jreleaser:full-release
+          ./mvnw -ntp -B jreleaser:full-release

--- a/README.md
+++ b/README.md
@@ -160,4 +160,4 @@ $ sudo ~/.sdkman/candidates/java/17.0.7-zulu/bin/java -jar pi4j-spring-boot-star
 This project was started by Daniel Frey and got further improved by DaShaun Carter during a few live-coding sessions:
 
 1. [Working on Pi4J Spring Boot](https://www.twitch.tv/videos/1828406758)
-1. [Spring Boot Pi4J Starter :: Testing my PR](https://www.twitch.tv/videos/1829189803)
+2. [Spring Boot Pi4J Starter :: Testing my PR](https://www.twitch.tv/videos/1829189803)

--- a/README.md
+++ b/README.md
@@ -56,7 +56,8 @@ $ sdk install java 17.0.7-zulu
 ```shell
 $ git clone https://github.com/Pi4J/pi4j-springboot.git
 $ cd pi4j-springboot
-$ mvn package
+$ chmod +x mvnw
+$ ./mvnw package
 ```
 
 * Run it as sudo to make sure Pi4J starts correctly.
@@ -65,7 +66,7 @@ $ mvn package
 $ sudo java -jar pi4j-spring-boot-starter-sample-app/target/pi4j-spring-boot-starter-sample-app-0.0.1.ea.jar 
 
 # Or when installed with SDKMAN
-$ sudo ~/.sdkman/candidates/java/19.0.2-zulu/bin/java -jar pi4j-spring-boot-starter-sample-app/target/pi4j-spring-boot-starter-sample-app-0.0.1.ea.jar
+$ sudo ~/.sdkman/candidates/java/17.0.7-zulu/bin/java -jar pi4j-spring-boot-starter-sample-app/target/pi4j-spring-boot-starter-sample-app-0.0.1.ea.jar
 ```
 
 * Check the output of the application:
@@ -94,7 +95,7 @@ $ sudo ~/.sdkman/candidates/java/19.0.2-zulu/bin/java -jar pi4j-spring-boot-star
 ...
 ```
 
-* Open browser with http://{RASPBERRY_PI_IP_ADDRESS}:8080/actuator/info
+* Open browser with `http://{RASPBERRY_PI_IP_ADDRESS}:8080/actuator/info`
 * Output on a Raspberry Pi 4 (but truncated the pins-section):
     ```json
     {

--- a/pi4j-spring-boot/src/test/java/com/pi4j/spring/boot/ContextTest.java
+++ b/pi4j-spring-boot/src/test/java/com/pi4j/spring/boot/ContextTest.java
@@ -22,7 +22,7 @@ class ContextTest {
     }
 
     @Test
-    void boardUnkownIfNotRunningOnPi() {
+    void boardUnknownIfNotRunningOnPi() {
         String osName = System.getProperty("os.name").toLowerCase();
         String osArch = System.getProperty("os.arch").toLowerCase();
         if (osName.contains("linux") && osArch.contains("arm")) {

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.2.5</version>
+        <version>3.3.4</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 
@@ -19,12 +19,12 @@
 
     <properties>
         <java.version>17</java.version>
-        <spring-boot.version>3.2.5</spring-boot.version>
+        <spring-boot.version>3.3.4</spring-boot.version>
         <pi4j.version>2.7.0</pi4j.version>
 
         <!-- Plugins -->
-        <jacoco-maven-plugin.version>0.8.10</jacoco-maven-plugin.version>
-        <jreleaser.version>1.3.1</jreleaser.version>
+        <jacoco-maven-plugin.version>0.8.12</jacoco-maven-plugin.version>
+        <jreleaser.version>1.14.0</jreleaser.version>
     </properties>
 
     <scm>
@@ -85,27 +85,27 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-deploy-plugin</artifactId>
-                    <version>3.0.0</version>
+                    <version>3.6.3</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.10.1</version>
+                    <version>3.13.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-javadoc-plugin</artifactId>
-                    <version>3.2.0</version>
+                    <version>3.10.1</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-jar-plugin</artifactId>
-                    <version>3.2.0</version>
+                    <version>3.4.2</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-sources-plugin</artifactId>
-                    <version>3.2.1</version>
+                    <version>3.15.0</version>
                 </plugin>
             </plugins>
         </pluginManagement>
@@ -182,7 +182,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-source-plugin</artifactId>
-                        <version>3.2.1</version>
+                        <version>3.3.1</version>
                         <executions>
                             <execution>
                                 <id>attach-sources</id>


### PR DESCRIPTION
This PR updates the build and release workflows to utilize the Maven wrapper (`./mvnw`) instead of relying on an installed Maven version. This ensures consistency across builds and simplifies CI setup. Additional changes include dependency and version updates and a minor test fix.

### Key Changes:

1.  **CI Workflow Updates**

    -   Replaced `mvn` commands with `./mvnw` to use the Maven wrapper.
    -   Added a step in `release.yml` and `build.yml` to set executable permissions for `mvnw`.
2.  **Dependency Version Upgrades in `pom.xml`**

    -   Updated several plugin versions, including:
        -   Spring Boot version to `3.3.4`.
        -   Jacoco Maven Plugin to `0.8.12`.
        -   JReleaser version to `1.14.0`.
3.  **Test Update**

    -   Fixed a typo in `ContextTest.java`: corrected `boardUnkownIfNotRunningOnPi()` to `boardUnknownIfNotRunningOnPi()`.
4.  **Documentation Updates**

    -   Updated the `README.md` to reflect the Maven wrapper usage for packaging and Java version corrections in examples.